### PR TITLE
Small README fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ A box with a width of `405px` and a height of `9.5em`.
 
 ```html
 <watched-box widthbreaks="405px" heightbreaks="9em" class="w-lte-405px h-gt-9em landscape"></watched-box>
+```
 
 ### Multiple breaks for each dimension, using different units
 


### PR DESCRIPTION
This PR adds a closing set of back ticks to an HTML code block in the section titled, "Single breaks for each dimension," which should fix a small formatting error in the rendered README.

Thanks for sharing `watched-box`!